### PR TITLE
fix: Add provider-specific parameter filtering for LLM factory

### DIFF
--- a/vibe_surf/backend/utils/llm_factory.py
+++ b/vibe_surf/backend/utils/llm_factory.py
@@ -41,17 +41,34 @@ def create_llm_from_profile(llm_profile):
         if not is_provider_supported(provider):
             raise ValueError(f"Unsupported provider: {provider}. Supported: {get_supported_providers()}")
         
-        # Common parameters
+        # Define provider-specific parameter support
+        provider_param_support = {
+            "openai": ["temperature", "max_tokens", "top_p", "frequency_penalty", "seed"],
+            "anthropic": ["temperature", "max_tokens", "top_p"],
+            "google": ["temperature", "max_tokens", "top_p"],
+            "azure_openai": ["temperature", "max_tokens", "top_p", "frequency_penalty", "seed"],
+            "groq": ["temperature", "max_tokens", "top_p"],
+            "ollama": ["temperature"],
+            "openrouter": ["temperature", "top_p"],  # OpenRouter doesn't support max_tokens
+            "deepseek": ["temperature", "max_tokens", "top_p"],
+            "aws_bedrock": ["temperature", "max_tokens"],
+            "anthropic_bedrock": ["temperature", "max_tokens"],
+            "openai_compatible": ["temperature", "max_tokens", "top_p", "frequency_penalty", "seed"]
+        }
+        
+        # Build common parameters based on provider support
+        supported_params = provider_param_support.get(provider, ["temperature", "max_tokens", "top_p", "frequency_penalty", "seed"])
         common_params = {}
-        if temperature is not None:
+        
+        if temperature is not None and "temperature" in supported_params:
             common_params["temperature"] = temperature
-        if max_tokens is not None:
+        if max_tokens is not None and "max_tokens" in supported_params:
             common_params["max_tokens"] = max_tokens
-        if top_p is not None:
+        if top_p is not None and "top_p" in supported_params:
             common_params["top_p"] = top_p
-        if frequency_penalty is not None:
+        if frequency_penalty is not None and "frequency_penalty" in supported_params:
             common_params["frequency_penalty"] = frequency_penalty
-        if seed is not None:
+        if seed is not None and "seed" in supported_params:
             common_params["seed"] = seed
         
         # Add provider-specific config if available


### PR DESCRIPTION
- Added provider_param_support mapping for each LLM provider
- Filter parameters before passing to LLM constructors
- Fixes OpenRouter 'max_tokens' parameter error
- Ensures other providers only receive supported params
- No breaking changes to existing functionality